### PR TITLE
Se corrigió el error de el link de ver documento actual

### DIFF
--- a/src/app/components/actualizar-registro/actualizar-registro.component.html
+++ b/src/app/components/actualizar-registro/actualizar-registro.component.html
@@ -68,11 +68,13 @@
             </div>
 
             <div class="col-12">
-
+              <label class="form-label" *ngIf="url"> 
+                <h3><a [href]="url">Ver documento actual</a></h3>
+            </label>
 
             </div>
 
-            <label class="form-label"> <h3><a [href]="url">Ver documento actual</a></h3></label>
+           
 
             <div class="mb-3">
 


### PR DESCRIPTION
El link, aparecia aunque no hubiera documento, y al darle click mandaba a la pagina de inicio